### PR TITLE
ESM, customizable config path, migration builders, config builder,

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
   <img src="https://github.com/user-attachments/assets/103be6a4-d02c-473a-b95b-39fd6a84d8a8" alt="Mongogrator" />
 </p>
 
+> Forked from [tepinly/mongogrator](https://github.com/tepinly/mongogrator) — original work by [@tepinly](https://github.com/tepinly).
+
 Mongogrator is a very fast database migration CLI for MongoDB. Its purpose is to easily create and run migrations for development and production stages
 
 ## Installing

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Commands:
    init [--js]                Initialize a new configuration file
    add [--config <path>]      Creates a new migration file with the provided name
    list [--config <path>]     List all migrations and their status
-   migrate [--config <path>]  Run all migrations that have not been applied yet
+   apply, migrate             Run all migrations that have not been applied yet
+                              (alias: migrate; accepts [--config <path>])
    version, -v, --version     Prints the current version of Mongogrator
 
 Flags:
@@ -122,15 +123,15 @@ Naturally, the status will be `NOT MIGRATED` as we haven't run the migration yet
 Run the migrations simply by calling
 
 ```sh
-mongogrator migrate
+mongogrator apply
 ```
 
 This will run all the migrations and log them to the database under the specified collection name in the config `logsCollectionName`
 
-For production purposes, you can pass the config file path to the `migrate` command directly via `--config` if the config isn't in the current working directory
+For production purposes, you can pass the config file path to the `apply` command directly via `--config` if the config isn't in the current working directory
 
 ```sh
-mongogrator migrate --config ./dist/mongogrator.config.js
+mongogrator apply --config ./dist/mongogrator.config.js
 ```
 
 Alternatively, set the `MONGOGRATOR_CONFIG_PATH` environment variable. This is handy when wiring a single `pnpm migrate` script that forwards arbitrary subcommands:

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Commands:
 Flags:
    --help, -h                 Prints the detailed description of the command
    --config <path>            Use a custom mongogrator config file
+
+Environment variables:
+   MONGOGRATOR_CONFIG_PATH    Equivalent of --config (--config wins if both are set)
 ```
 
 ## Usage guide
@@ -130,7 +133,24 @@ For production purposes, you can pass the config file path to the `migrate` comm
 mongogrator migrate --config ./dist/mongogrator.config.js
 ```
 
-When `--config` is used, `migrationsPath` is resolved relative to the config file's directory.
+Alternatively, set the `MONGOGRATOR_CONFIG_PATH` environment variable. This is handy when wiring a single `pnpm migrate` script that forwards arbitrary subcommands:
+
+```jsonc
+// package.json
+{
+  "scripts": {
+    "migrate": "MONGOGRATOR_CONFIG_PATH=./src/migrations/mongogrator.config.ts mongogrator"
+  }
+}
+```
+
+```sh
+pnpm migrate apply   # → mongogrator apply  (reads MONGOGRATOR_CONFIG_PATH)
+pnpm migrate list    # → mongogrator list
+pnpm migrate add foo # → mongogrator add foo
+```
+
+If both are provided, `--config` wins over the env var. In either case, `migrationsPath` is resolved relative to the config file's directory.
 
 Now if you run the `list` command again, it will reveal that the migration file has been successfully executed
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ Now if you run the `list` command again, it will reveal that the migration file 
 }
 ```
 
+By default `_id` is an auto-generated MongoDB `ObjectId`. If you'd rather use a different id type (e.g. a plain string UUID), pass a `generateId` function in the config — see [Custom `_id` in the logs collection](#custom-_id-in-the-logs-collection) below.
+
 ## Configuration
 
 ```ts
@@ -210,8 +212,34 @@ Now if you run the `list` command again, it will reveal that the migration file 
   format: 'ts', // Format type of the migration files ['ts', 'js']
   callbacksBeforeMigrations: [], // Async hooks ({ db, client }) => Promise<void>, run once before the batch
   callbacksAfterMigrations: [], // Async hooks ({ db, client }) => Promise<void>, run once after the batch
+  generateId: () => crypto.randomUUID(), // Optional. Sets the _id of every row inserted into the logs collection. Omit to let MongoDB auto-generate an ObjectId.
 }
 ```
+
+### Custom `_id` in the logs collection
+
+By default Mongogrator does not set `_id` on the rows it writes to the logs collection (`logsCollectionName`), so the MongoDB driver auto-generates a fresh `ObjectId` per insert. If you'd rather store a different id type — for example a plain string UUID so the field is easier to read or copy from a GUI — pass a `generateId` function in the config:
+
+```ts
+import { buildMongogratorConfig } from '@danieljanocha/mongogrator'
+import { randomUUID } from 'node:crypto'
+
+export default buildMongogratorConfig({
+  url: 'mongodb://localhost:27017',
+  database: 'test',
+  migrationsPath: './migrations',
+  logsCollectionName: 'migrations',
+  format: 'ts',
+  generateId: () => randomUUID(),
+})
+```
+
+Notes:
+
+- `generateId` is called once per applied migration, and its return value is written as that row's `_id`.
+- It affects **only** the logs collection. Documents your own migrations insert are not touched.
+- Return whatever BSON-compatible type you want — a string (e.g. `randomUUID()`), an `ObjectId`, a number, etc.
+- Omit the field to keep the default behavior (auto-generated `ObjectId`).
 
 For a type-safe config, use the `buildMongogratorConfig` builder. It validates the shape at load time and gives you autocomplete on the input:
 

--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ The following is an example of a newly created ts migration file
 import { buildMigration } from '@danieljanocha/mongogrator'
 
 export default buildMigration({
-  migrate: async (_db) => {
+  migrate: async ({ db, client }) => {
     // Migration code here
   },
 })
 ```
 
-The migrations are executed through the native MongoDB Node.js driver.
+The migrations are executed through the native MongoDB Node.js driver. Each migration receives both the default `db` (resolved from `config.database`) and the underlying `client` (`MongoClient`) so you can reach additional databases when needed.
 
 ### Migration query example
 
@@ -97,8 +97,29 @@ The migrations are executed through the native MongoDB Node.js driver.
 import { buildMigration } from '@danieljanocha/mongogrator'
 
 export default buildMigration({
-  migrate: async (db) => {
+  migrate: async ({ db }) => {
     await db.collection('users').insertOne({ name: 'Alex' })
+  },
+})
+```
+
+### Multi-database migrations
+
+If you run several databases off the same cluster (e.g. one for auth + one per app client), use `client` to address them explicitly:
+
+```ts
+import { buildMigration } from '@danieljanocha/mongogrator'
+
+export default buildMigration({
+  migrate: async ({ client }) => {
+    const authDb = client.db('auth')
+    const twitchDb = client.db('twitch')
+    const facebookDb = client.db('facebook')
+
+    await authDb.collection('users').createIndex({ email: 1 }, { unique: true })
+    for (const appDb of [twitchDb, facebookDb]) {
+      await appDb.collection('sessions').createIndex({ createdAt: 1 })
+    }
   },
 })
 ```
@@ -187,8 +208,8 @@ Now if you run the `list` command again, it will reveal that the migration file 
   migrationsPath: './migrations', // Migrations directory relative to the location of the config file
   logsCollectionName: 'migrations', // Name of the logs collection that will be stored in the database
   format: 'ts', // Format type of the migration files ['ts', 'js']
-  callbacksBeforeMigrations: [], // Async hooks (args: { db }) => Promise<void>, run once before the batch
-  callbacksAfterMigrations: [], // Async hooks (args: { db }) => Promise<void>, run once after the batch
+  callbacksBeforeMigrations: [], // Async hooks ({ db, client }) => Promise<void>, run once before the batch
+  callbacksAfterMigrations: [], // Async hooks ({ db, client }) => Promise<void>, run once after the batch
 }
 ```
 
@@ -214,7 +235,7 @@ Migration files use the same builder pattern with a forced `default` export — 
 import { buildMigration } from '@danieljanocha/mongogrator'
 
 export default buildMigration({
-  migrate: async (db) => {
+  migrate: async ({ db }) => {
     await db.collection('users').insertOne({ name: 'Alex' })
   },
 })

--- a/README.md
+++ b/README.md
@@ -69,32 +69,27 @@ This will create the migration file under the directory key assigned in the conf
 The following is an example of a newly created ts migration file
 
 ```ts
-import type { Db } from 'mongodb'
+import { buildMigration } from '@danieljanocha/mongogrator'
 
-/**
- * This function is called when the migration is run.
- * @param _db The mongodb database object that's passed to the migration
- */
-export const migrate = async (_db: Db): Promise<void> => {
-  // Migration code here
-}
+export default buildMigration({
+  migrate: async (_db) => {
+    // Migration code here
+  },
+})
 ```
 
-The migrations are executed through the native MongoDB Node.js driver
+The migrations are executed through the native MongoDB Node.js driver.
 
 ### Migration query example
 
 ```ts
-import type { Db } from 'mongodb'
+import { buildMigration } from '@danieljanocha/mongogrator'
 
-/**
- * This function is called when the migration is run.
- * @param _db The mongodb database object that's passed to the migration
- */
-export const migrate = async (_db: Db): Promise<void> => {
-  // Migration code here
-  _db.collection('users').insertOne({ name: 'Alex' })
-}
+export default buildMigration({
+  migrate: async (db) => {
+    await db.collection('users').insertOne({ name: 'Alex' })
+  },
+})
 ```
 
 ### Migrations list
@@ -169,16 +164,32 @@ Now if you run the `list` command again, it will reveal that the migration file 
 }
 ```
 
-For a type-safe config, parse against the exported schema:
+For a type-safe config, use the `buildMongogratorConfig` builder. It validates the shape at load time and gives you autocomplete on the input:
 
 ```ts
-import { mongogratorConfigSchema, type TMongogratorConfig } from '@danieljanocha/mongogrator'
+// mongogrator.config.ts
+import { buildMongogratorConfig } from '@danieljanocha/mongogrator'
 
-const config: TMongogratorConfig = mongogratorConfigSchema.parse({
-  // ...
+export default buildMongogratorConfig({
+  url: 'mongodb://localhost:27017',
+  database: 'test',
+  migrationsPath: './migrations',
+  logsCollectionName: 'migrations',
+  format: 'ts',
 })
+```
 
-export default config
+Migration files use the same builder pattern with a forced `default` export — this prevents typos like accidentally exporting `migratee` instead of `migrate`:
+
+```ts
+// migrations/20240923150201806_insert_user.ts
+import { buildMigration } from '@danieljanocha/mongogrator'
+
+export default buildMigration({
+  migrate: async (db) => {
+    await db.collection('users').insertOne({ name: 'Alex' })
+  },
+})
 ```
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -48,7 +48,12 @@ Flags:
 
 Environment variables:
    MONGOGRATOR_CONFIG_PATH    Equivalent of --config (--config wins if both are set)
+   NO_COLOR                   Set to any value to disable colored log output
 ```
+
+Log output is colorized by default (blue for info, red for errors) so
+Mongogrator lines stand out in CI build logs. Set `NO_COLOR` to any value to
+force plain, uncolored output (see [no-color.org](https://no-color.org)).
 
 ## Usage guide
 

--- a/README.md
+++ b/README.md
@@ -6,17 +6,23 @@ Mongogrator is a very fast database migration CLI for MongoDB. Its purpose is to
 
 ## Installing
 
-Using the following command, it will automatically download, install and add Mongogrator to `PATH`
-
-### MacOS/Linux
-
 ```bash
-curl -fsSL git.new/mongogrator-installer.sh | bash
+pnpm add @danieljanocha/mongogrator
+# or: npm i @danieljanocha/mongogrator
+# or: bun add @danieljanocha/mongogrator
 ```
 
-### Windows
+The CLI binary is exposed as `mongogrator` (run via `pnpm exec mongogrator`, `npx mongogrator`, or `bunx mongogrator`).
 
-```powershell
+### Standalone binary (upstream)
+
+The upstream project also ships a one-line installer that downloads a prebuilt binary:
+
+```bash
+# MacOS/Linux
+curl -fsSL git.new/mongogrator-installer.sh | bash
+
+# Windows
 cmd /c "curl -L https://git.new/mongogrator-installer.ps1 | powershell -c -"
 ```
 
@@ -27,14 +33,15 @@ Mongogrator CLI
 Usage: mongogrator <command> [options]
 
 Commands:
-   init [--js]               Initialize a new configuration file
-   add                       Creates a new migration file with the provided name
-   list                      List all migrations and their status
-   migrate [config_path]     Run all migrations that have not been applied yet
-   version, -v, --version    Prints the current version of Mongogrator
+   init [--js]                Initialize a new configuration file
+   add [--config <path>]      Creates a new migration file with the provided name
+   list [--config <path>]     List all migrations and their status
+   migrate [--config <path>]  Run all migrations that have not been applied yet
+   version, -v, --version     Prints the current version of Mongogrator
 
 Flags:
-   --help, -h                Prints the detailed description of the command
+   --help, -h                 Prints the detailed description of the command
+   --config <path>            Use a custom mongogrator config file
 ```
 
 ## Usage guide
@@ -120,11 +127,13 @@ mongogrator migrate
 
 This will run all the migrations and log them to the database under the specified collection name in the config `logsCollectionName`
 
-For production purposes, you can pass the config path to the `migrate` command directly if it's not accessible under the same path
+For production purposes, you can pass the config file path to the `migrate` command directly via `--config` if the config isn't in the current working directory
 
 ```sh
-mongogrator migrate /dist
+mongogrator migrate --config ./dist/mongogrator.config.js
 ```
+
+When `--config` is used, `migrationsPath` is resolved relative to the config file's directory.
 
 Now if you run the `list` command again, it will reveal that the migration file has been successfully executed
 
@@ -152,10 +161,24 @@ Now if you run the `list` command again, it will reveal that the migration file 
 {
   url: 'mongodb://localhost:27017', // Cluster url
   database: 'test', // Database name for which the migrations will be executed
-  migrationsPath: './migrations', // Migrations directory relative to the location of the commands
+  migrationsPath: './migrations', // Migrations directory relative to the location of the config file
   logsCollectionName: 'migrations', // Name of the logs collection that will be stored in the database
   format: 'ts', // Format type of the migration files ['ts', 'js']
+  callbacksBeforeMigrations: [], // Async hooks (args: { db }) => Promise<void>, run once before the batch
+  callbacksAfterMigrations: [], // Async hooks (args: { db }) => Promise<void>, run once after the batch
 }
+```
+
+For a type-safe config, parse against the exported schema:
+
+```ts
+import { mongogratorConfigSchema, type TMongogratorConfig } from '@danieljanocha/mongogrator'
+
+const config: TMongogratorConfig = mongogratorConfigSchema.parse({
+  // ...
+})
+
+export default config
 ```
 
 > [!IMPORTANT]

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,91 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "mongogrator",
+      "dependencies": {
+        "mongodb": "^6.10.0",
+        "zod": "^3.23.8",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^1.9.4",
+        "@types/bun": "latest",
+        "rimraf": "^6.0.1",
+        "typescript": "^5.6.3",
+      },
+    },
+  },
+  "packages": {
+    "@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@1.9.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@1.9.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@1.9.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
+
+    "@mongodb-js/saslprep": ["@mongodb-js/saslprep@1.4.11", "", { "dependencies": { "sparse-bitfield": "^3.0.3" } }, "sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA=="],
+
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
+    "@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
+
+    "@types/webidl-conversions": ["@types/webidl-conversions@7.0.3", "", {}, "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="],
+
+    "@types/whatwg-url": ["@types/whatwg-url@11.0.5", "", { "dependencies": { "@types/webidl-conversions": "*" } }, "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
+
+    "bson": ["bson@6.10.4", "", {}, "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
+
+    "lru-cache": ["lru-cache@11.3.6", "", {}, "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A=="],
+
+    "memory-pager": ["memory-pager@1.5.0", "", {}, "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="],
+
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "mongodb": ["mongodb@6.21.0", "", { "dependencies": { "@mongodb-js/saslprep": "^1.3.0", "bson": "^6.10.4", "mongodb-connection-string-url": "^3.0.2" }, "peerDependencies": { "@aws-sdk/credential-providers": "^3.188.0", "@mongodb-js/zstd": "^1.1.0 || ^2.0.0", "gcp-metadata": "^5.2.0", "kerberos": "^2.0.1", "mongodb-client-encryption": ">=6.0.0 <7", "snappy": "^7.3.2", "socks": "^2.7.1" }, "optionalPeers": ["@aws-sdk/credential-providers", "@mongodb-js/zstd", "gcp-metadata", "kerberos", "mongodb-client-encryption", "snappy", "socks"] }, "sha512-URyb/VXMjJ4da46OeSXg+puO39XH9DeQpWCslifrRn9JWugy0D+DvvBvkm2WxmHe61O/H19JM66p1z7RHVkZ6A=="],
+
+    "mongodb-connection-string-url": ["mongodb-connection-string-url@3.0.2", "", { "dependencies": { "@types/whatwg-url": "^11.0.2", "whatwg-url": "^14.1.0 || ^13.0.0" } }, "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA=="],
+
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
+    "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "rimraf": ["rimraf@6.1.3", "", { "dependencies": { "glob": "^13.0.3", "package-json-from-dist": "^1.0.1" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA=="],
+
+    "sparse-bitfield": ["sparse-bitfield@3.0.3", "", { "dependencies": { "memory-pager": "^1.0.2" } }, "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ=="],
+
+    "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
+
+    "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
       "name": "mongogrator",
       "dependencies": {
         "mongodb": "^6.10.0",
-        "zod": "^3.23.8",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
@@ -86,6 +86,6 @@
 
     "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,7 @@
     "": {
       "name": "mongogrator",
       "dependencies": {
+        "jiti": "^2.7.0",
         "mongodb": "^6.10.0",
         "zod": "^4.3.6",
       },
@@ -53,6 +54,8 @@
     "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
+
+    "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "lru-cache": ["lru-cache@11.3.6", "", {}, "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danieljanocha/mongogrator",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Mongogrator is a lightweight typescript-based package for MongoDB database migrations",
   "author": "tepinly",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danieljanocha/mongogrator",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Mongogrator is a lightweight typescript-based package for MongoDB database migrations",
   "author": "tepinly",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danieljanocha/mongogrator",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Mongogrator is a lightweight typescript-based package for MongoDB database migrations",
   "author": "tepinly",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "scripts": {
     "make:macos": "rimraf bin/mongogrator && make macos-arm && mv bin/mongogrator-mac-arm64 bin/mongogrator",
     "build": "tsc",
+    "prepare": "tsc",
     "lint": "biome check ."
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danieljanocha/mongogrator",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "description": "Mongogrator is a lightweight typescript-based package for MongoDB database migrations",
   "author": "tepinly",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -4,14 +4,20 @@
   "description": "Mongogrator is a lightweight typescript-based package for MongoDB database migrations",
   "author": "tepinly",
   "license": "MIT",
-  "type": "commonjs",
-  "main": "dist/index.js",
+  "type": "module",
+  "main": "./dist/lib.js",
+  "types": "./dist/lib.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/lib.d.ts",
+      "import": "./dist/lib.js"
+    }
+  },
   "bin": {
     "mongogrator": "./dist/index.js"
   },
   "files": [
     "dist",
-    "assets",
     "tsconfig.json"
   ],
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danieljanocha/mongogrator",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Mongogrator is a lightweight typescript-based package for MongoDB database migrations",
   "author": "tepinly",
   "license": "MIT",
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "mongodb": "^6.10.0",
-    "zod": "^3.23.8"
+    "zod": "^4.3.6"
   },
   "maintainers": [
     {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
-  "name": "mongogrator",
-  "version": "1.0.2",
+  "name": "@danieljanocha/mongogrator",
+  "version": "1.1.0",
   "description": "Mongogrator is a lightweight typescript-based package for MongoDB database migrations",
   "author": "tepinly",
   "license": "MIT",
   "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "./dist/lib.js",
   "types": "./dist/lib.d.ts",
   "exports": {
@@ -14,7 +17,7 @@
     }
   },
   "bin": {
-    "mongogrator": "./dist/index.js"
+    "mongogrator": "dist/index.js"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danieljanocha/mongogrator",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Mongogrator is a lightweight typescript-based package for MongoDB database migrations",
   "author": "tepinly",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danieljanocha/mongogrator",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Mongogrator is a lightweight typescript-based package for MongoDB database migrations",
   "author": "tepinly",
   "license": "MIT",
@@ -49,6 +49,7 @@
     "typescript": "^5.6.3"
   },
   "dependencies": {
+    "jiti": "^2.7.0",
     "mongodb": "^6.10.0",
     "zod": "^4.3.6"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danieljanocha/mongogrator",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Mongogrator is a lightweight typescript-based package for MongoDB database migrations",
   "author": "tepinly",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danieljanocha/mongogrator",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Mongogrator is a lightweight typescript-based package for MongoDB database migrations",
   "author": "tepinly",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danieljanocha/mongogrator",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Mongogrator is a lightweight typescript-based package for MongoDB database migrations",
   "author": "tepinly",
   "license": "MIT",

--- a/src/cli/CliParser.ts
+++ b/src/cli/CliParser.ts
@@ -1,4 +1,4 @@
-import type { CommandOptions } from '../commands/BaseCommandStrategy'
+import type { CommandOptions } from '../commands/BaseCommandStrategy.js'
 
 export class CliParser {
 	private command
@@ -7,15 +7,38 @@ export class CliParser {
 
 	constructor(argv: typeof process.argv) {
 		this.command = argv[2] ?? ''
-		this.args = argv.slice(3).filter((arg) => !arg.startsWith('-'))
-		this.flags = Object.fromEntries(
-			argv
-				.filter((arg) => arg.startsWith('-'))
-				.map((flag) => {
-					const [key, value = true] = flag.split('=')
-					return [key.startsWith('--') ? key.slice(2) : key.slice(1), value]
-				}),
-		)
+		const rest = argv.slice(3)
+		const args: string[] = []
+		const flags: CommandOptions['flags'] = {}
+
+		for (let i = 0; i < rest.length; i++) {
+			const token = rest[i]
+			if (!token.startsWith('-')) {
+				args.push(token)
+				continue
+			}
+
+			const stripped = token.startsWith('--') ? token.slice(2) : token.slice(1)
+			const eqIndex = stripped.indexOf('=')
+
+			if (eqIndex !== -1) {
+				const key = stripped.slice(0, eqIndex)
+				const value = stripped.slice(eqIndex + 1)
+				flags[key] = value
+				continue
+			}
+
+			const next = rest[i + 1]
+			if (next !== undefined && !next.startsWith('-')) {
+				flags[stripped] = next
+				i++
+			} else {
+				flags[stripped] = true
+			}
+		}
+
+		this.args = args
+		this.flags = flags
 	}
 
 	public get commandName(): string {

--- a/src/commands/AddCommand.ts
+++ b/src/commands/AddCommand.ts
@@ -1,30 +1,43 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { ConfigurationHandler } from '../config/ConfigurationHandler'
-import { migrationTemplates } from '../config/templates'
-import { MongogratorError } from '../errors/MongogratorError'
-import { MongogratorLogger } from '../loggers/MongogratorLogger'
-import { BaseCommandStrategy } from './BaseCommandStrategy'
+import { ConfigurationHandler } from '../config/ConfigurationHandler.js'
+import { migrationTemplates } from '../config/templates.js'
+import { MongogratorError } from '../errors/MongogratorError.js'
+import { MongogratorLogger } from '../loggers/MongogratorLogger.js'
+import { BaseCommandStrategy } from './BaseCommandStrategy.js'
 
 export class AddCommand extends BaseCommandStrategy {
 	static triggers = ['add']
 	static description = 'Creates a new migration file with the provided name'
+	static flags: string[] = ['[--config <path>]']
 	static detailedDescription = `
 		This command creates a new migration file in the configured migrationsPath directory.
-		It takes one argument, the name of the migration file to be created. It appends a timestamp 
+		It takes one argument, the name of the migration file to be created. It appends a timestamp
 		to the name to ensure uniqueness. The migration file can be generated in either JavaScript (.js)
 		or TypeScript (.ts) format, based on the specified configuration in the mongogrator.config file.
+		Pass --config <path> to use a specific config file; the migration is then created relative to
+		the config file's directory.
 	`
 
 	async execute() {
 		const fileName =
 			this.commandOptions.args[0] ?? this.throwWhenNoFileNameProvided()
-		const config = await ConfigurationHandler.readConfig()
-		this.createMigrationDirectoryIfNotExists(config.migrationsPath)
+
+		const configPath =
+			typeof this.commandOptions.flags.config === 'string'
+				? this.commandOptions.flags.config
+				: undefined
+
+		const { config, configFilePath } = await ConfigurationHandler.readConfig({
+			configPath,
+		})
+
+		const baseDir = configPath ? path.dirname(configFilePath) : process.cwd()
+		const migrationsDir = path.resolve(baseDir, config.migrationsPath)
+		this.createMigrationDirectoryIfNotExists(migrationsDir)
 
 		const newFilePath = path.join(
-			process.cwd(),
-			config.migrationsPath,
+			migrationsDir,
 			`${this.getTimestamp()}_${fileName}.${config.format}`,
 		)
 

--- a/src/commands/AddCommand.ts
+++ b/src/commands/AddCommand.ts
@@ -15,8 +15,9 @@ export class AddCommand extends BaseCommandStrategy {
 		It takes one argument, the name of the migration file to be created. It appends a timestamp
 		to the name to ensure uniqueness. The migration file can be generated in either JavaScript (.js)
 		or TypeScript (.ts) format, based on the specified configuration in the mongogrator.config file.
-		Pass --config <path> to use a specific config file; the migration is then created relative to
-		the config file's directory.
+		Pass --config <path> or set MONGOGRATOR_CONFIG_PATH to use a specific config file
+		(--config wins over the env var); the migration is then created relative to the config
+		file's directory.
 	`
 
 	async execute() {
@@ -32,8 +33,10 @@ export class AddCommand extends BaseCommandStrategy {
 			configPath,
 		})
 
-		const baseDir = configPath ? path.dirname(configFilePath) : process.cwd()
-		const migrationsDir = path.resolve(baseDir, config.migrationsPath)
+		const migrationsDir = path.resolve(
+			path.dirname(configFilePath),
+			config.migrationsPath,
+		)
 		this.createMigrationDirectoryIfNotExists(migrationsDir)
 
 		const newFilePath = path.join(

--- a/src/commands/ApplyCommand.ts
+++ b/src/commands/ApplyCommand.ts
@@ -8,8 +8,8 @@ import { MongogratorError } from '../errors/MongogratorError.js'
 import { MongogratorLogger } from '../loggers/MongogratorLogger.js'
 import { BaseCommandStrategy } from './BaseCommandStrategy.js'
 
-export class MigrateCommand extends BaseCommandStrategy {
-	static triggers = ['migrate']
+export class ApplyCommand extends BaseCommandStrategy {
+	static triggers = ['apply', 'migrate']
 	static description = 'Run all migrations that have not been applied yet'
 	static flags: string[] = ['[--config <path>]']
 	static detailedDescription = `

--- a/src/commands/ApplyCommand.ts
+++ b/src/commands/ApplyCommand.ts
@@ -1,11 +1,11 @@
 import path from 'node:path'
-import { pathToFileURL } from 'node:url'
 import { ConfigurationHandler } from '../config/ConfigurationHandler.js'
 import type { MongogratorMigration } from '../config/config.js'
 import { MigrationsService } from '../db/MigrationsService.js'
 import { Client } from '../db/MongoDb.js'
 import { MongogratorError } from '../errors/MongogratorError.js'
 import { MongogratorLogger } from '../loggers/MongogratorLogger.js'
+import { loadModule } from '../moduleLoader.js'
 import { BaseCommandStrategy } from './BaseCommandStrategy.js'
 
 export class ApplyCommand extends BaseCommandStrategy {
@@ -69,8 +69,8 @@ async function loadMigration(
 	absPath: string,
 	displayName: string,
 ): Promise<MongogratorMigration> {
-	const mod = await import(pathToFileURL(absPath).href)
-	const migration = mod.default as MongogratorMigration | undefined
+	const mod = (await loadModule(absPath)) as { default?: MongogratorMigration }
+	const migration = mod.default
 	if (!migration || typeof migration.migrate !== 'function') {
 		throw new MongogratorError(
 			`Migration "${displayName}" must default-export a value created with buildMigration({ migrate })`,

--- a/src/commands/ApplyCommand.ts
+++ b/src/commands/ApplyCommand.ts
@@ -39,9 +39,9 @@ export class ApplyCommand extends BaseCommandStrategy {
 		const migrationFiles = MigrationsService.getMigrations([migrationsDir])
 		const clientInstance = new Client(config)
 
-		await clientInstance.run(async ({ collection, db }) => {
+		await clientInstance.run(async ({ collection, db, client }) => {
 			for (const cb of config.callbacksBeforeMigrations) {
-				await cb({ db })
+				await cb({ db, client })
 			}
 
 			const migrationsService = new MigrationsService(collection)
@@ -52,14 +52,14 @@ export class ApplyCommand extends BaseCommandStrategy {
 						path.join(migrationsDir, file),
 						file,
 					)
-					await migration.migrate(db)
+					await migration.migrate({ db, client })
 					await migrationsService.insertApplied(path.parse(file).name)
 					MongogratorLogger.logInfo(`Migration ${file} applied`)
 				}
 			}
 
 			for (const cb of config.callbacksAfterMigrations) {
-				await cb({ db })
+				await cb({ db, client })
 			}
 		})
 	}

--- a/src/commands/ApplyCommand.ts
+++ b/src/commands/ApplyCommand.ts
@@ -44,7 +44,10 @@ export class ApplyCommand extends BaseCommandStrategy {
 				await cb({ db, client })
 			}
 
-			const migrationsService = new MigrationsService(collection)
+			const migrationsService = new MigrationsService(
+				collection,
+				config.generateId,
+			)
 			const appliedMigrationsSet = await migrationsService.getAppliedSet()
 			for (const file of migrationFiles) {
 				if (!appliedMigrationsSet.has(path.parse(file).name)) {

--- a/src/commands/CommandExecutor.ts
+++ b/src/commands/CommandExecutor.ts
@@ -1,9 +1,9 @@
-import { CliParser } from '../cli/CliParser'
-import { AddCommand } from './AddCommand'
-import { InitCommand } from './InitCommand'
-import { ListCommand } from './ListCommand'
-import { MigrateCommand } from './MigrateCommand'
-import { VersionCommand } from './VersionCommand'
+import { CliParser } from '../cli/CliParser.js'
+import { AddCommand } from './AddCommand.js'
+import { InitCommand } from './InitCommand.js'
+import { ListCommand } from './ListCommand.js'
+import { MigrateCommand } from './MigrateCommand.js'
+import { VersionCommand } from './VersionCommand.js'
 
 type TCommand = CommandExecutor['commandsList'][number]
 export class CommandExecutor {
@@ -65,6 +65,11 @@ export class CommandExecutor {
 				''.padStart(PADDING_START),
 				'--help, -h'.padEnd(PADDING_END),
 				'Prints the detailed description of the command',
+			)
+			console.log(
+				''.padStart(PADDING_START),
+				'--config <path>'.padEnd(PADDING_END),
+				'Use a custom mongogrator config file (e.g. ./infra/mongogrator.config.ts)',
 			)
 			process.exit(0)
 		}

--- a/src/commands/CommandExecutor.ts
+++ b/src/commands/CommandExecutor.ts
@@ -1,4 +1,5 @@
 import { CliParser } from '../cli/CliParser.js'
+import { version } from '../pkg.js'
 import { AddCommand } from './AddCommand.js'
 import { ApplyCommand } from './ApplyCommand.js'
 import { InitCommand } from './InitCommand.js'
@@ -46,7 +47,7 @@ export class CommandExecutor {
 		}
 		// if the commandName is not found, print the general help message
 		if (!chosenCommand) {
-			console.log('Mongogrator CLI')
+			console.log(`Mongogrator CLI v${version}`)
 			console.log('Usage: mongogrator <command> [options]')
 			console.log('\nCommands:')
 			const PADDING_END = 25

--- a/src/commands/CommandExecutor.ts
+++ b/src/commands/CommandExecutor.ts
@@ -1,8 +1,8 @@
 import { CliParser } from '../cli/CliParser.js'
 import { AddCommand } from './AddCommand.js'
+import { ApplyCommand } from './ApplyCommand.js'
 import { InitCommand } from './InitCommand.js'
 import { ListCommand } from './ListCommand.js'
-import { MigrateCommand } from './MigrateCommand.js'
 import { VersionCommand } from './VersionCommand.js'
 
 type TCommand = CommandExecutor['commandsList'][number]
@@ -14,7 +14,7 @@ export class CommandExecutor {
 		InitCommand,
 		AddCommand,
 		ListCommand,
-		MigrateCommand,
+		ApplyCommand,
 		VersionCommand,
 	] as const
 

--- a/src/commands/CommandExecutor.ts
+++ b/src/commands/CommandExecutor.ts
@@ -71,6 +71,11 @@ export class CommandExecutor {
 				'--config <path>'.padEnd(PADDING_END),
 				'Use a custom mongogrator config file (e.g. ./infra/mongogrator.config.ts)',
 			)
+			console.log(
+				''.padStart(PADDING_START),
+				'MONGOGRATOR_CONFIG_PATH'.padEnd(PADDING_END),
+				'Env var equivalent of --config (--config wins if both are set)',
+			)
 			process.exit(0)
 		}
 	}

--- a/src/commands/InitCommand.ts
+++ b/src/commands/InitCommand.ts
@@ -1,6 +1,6 @@
-import { ConfigurationHandler } from '../config/ConfigurationHandler'
-import { CONFIG_JS_FILE_NAME, CONFIG_TS_FILE_NAME } from '../config/config'
-import { BaseCommandStrategy } from './BaseCommandStrategy'
+import { ConfigurationHandler } from '../config/ConfigurationHandler.js'
+import { CONFIG_JS_FILE_NAME, CONFIG_TS_FILE_NAME } from '../config/config.js'
+import { BaseCommandStrategy } from './BaseCommandStrategy.js'
 
 export class InitCommand extends BaseCommandStrategy {
 	static triggers = ['init']

--- a/src/commands/ListCommand.ts
+++ b/src/commands/ListCommand.ts
@@ -13,7 +13,8 @@ export class ListCommand extends BaseCommandStrategy {
 		It checks each migration file to determine whether it has been applied to the database.
 		Each migration will be displayed with a status of either "MIGRATED" if it has been applied,
 		or "NOT MIGRATED" if it has not been applied yet.
-		Pass --config <path> to use a specific config file.
+		Pass --config <path> or set MONGOGRATOR_CONFIG_PATH to use a specific config file
+		(--config wins over the env var).
 	`
 
 	async execute() {
@@ -26,8 +27,10 @@ export class ListCommand extends BaseCommandStrategy {
 			configPath,
 		})
 
-		const baseDir = configPath ? path.dirname(configFilePath) : process.cwd()
-		const migrationsDir = path.resolve(baseDir, config.migrationsPath)
+		const migrationsDir = path.resolve(
+			path.dirname(configFilePath),
+			config.migrationsPath,
+		)
 		const files = MigrationsService.getMigrations([migrationsDir])
 		const clientInstance = new Client(config)
 

--- a/src/commands/ListCommand.ts
+++ b/src/commands/ListCommand.ts
@@ -1,25 +1,34 @@
 import path from 'node:path'
-import { ConfigurationHandler } from '../config/ConfigurationHandler'
-import { MigrationsService } from '../db/MigrationsService'
-import { Client } from '../db/MongoDb'
-import { BaseCommandStrategy } from './BaseCommandStrategy'
+import { ConfigurationHandler } from '../config/ConfigurationHandler.js'
+import { MigrationsService } from '../db/MigrationsService.js'
+import { Client } from '../db/MongoDb.js'
+import { BaseCommandStrategy } from './BaseCommandStrategy.js'
 
 export class ListCommand extends BaseCommandStrategy {
 	static triggers = ['list']
 	static description = 'List all migrations and their status'
+	static flags: string[] = ['[--config <path>]']
 	static detailedDescription = `
 		This command lists all the migration files located in the configured migrations directory.
 		It checks each migration file to determine whether it has been applied to the database.
 		Each migration will be displayed with a status of either "MIGRATED" if it has been applied,
 		or "NOT MIGRATED" if it has not been applied yet.
+		Pass --config <path> to use a specific config file.
 	`
 
 	async execute() {
-		const config = await ConfigurationHandler.readConfig()
-		const files = MigrationsService.getMigrations([
-			process.cwd(),
-			config.migrationsPath,
-		])
+		const configPath =
+			typeof this.commandOptions.flags.config === 'string'
+				? this.commandOptions.flags.config
+				: undefined
+
+		const { config, configFilePath } = await ConfigurationHandler.readConfig({
+			configPath,
+		})
+
+		const baseDir = configPath ? path.dirname(configFilePath) : process.cwd()
+		const migrationsDir = path.resolve(baseDir, config.migrationsPath)
+		const files = MigrationsService.getMigrations([migrationsDir])
 		const clientInstance = new Client(config)
 
 		await clientInstance.run(async ({ collection }) => {

--- a/src/commands/MigrateCommand.ts
+++ b/src/commands/MigrateCommand.ts
@@ -1,38 +1,58 @@
 import path from 'node:path'
-import { ConfigurationHandler } from '../config/ConfigurationHandler'
-import { MigrationsService } from '../db/MigrationsService'
-import { Client } from '../db/MongoDb'
-import { MongogratorLogger } from '../loggers/MongogratorLogger'
-import { BaseCommandStrategy } from './BaseCommandStrategy'
+import { pathToFileURL } from 'node:url'
+import { ConfigurationHandler } from '../config/ConfigurationHandler.js'
+import { MigrationsService } from '../db/MigrationsService.js'
+import { Client } from '../db/MongoDb.js'
+import { MongogratorLogger } from '../loggers/MongogratorLogger.js'
+import { BaseCommandStrategy } from './BaseCommandStrategy.js'
 
 export class MigrateCommand extends BaseCommandStrategy {
 	static triggers = ['migrate']
 	static description = 'Run all migrations that have not been applied yet'
-	static args: string[] = ['[config_path]']
+	static flags: string[] = ['[--config <path>]']
 	static detailedDescription = `
 		This command executes all pending migration files in the migrations directory.
 		Migrations that have already been applied are skipped.
-		The command should be run from the same location as the config file.
+		By default the config file is loaded from the current working directory; pass
+		--config <path> to point at a specific mongogrator.config.{ts,js} file.
 		The config file determines the location of the migrations folder.
 	`
 
 	async execute() {
-		const customPath = this.commandOptions.args[0] ?? ''
-		const config = await ConfigurationHandler.readConfig(customPath)
-		const migrationsPath = [process.cwd(), customPath, config.migrationsPath]
-		const migrationFiles = MigrationsService.getMigrations(migrationsPath)
+		const configPath =
+			typeof this.commandOptions.flags.config === 'string'
+				? this.commandOptions.flags.config
+				: undefined
+
+		const { config, configFilePath } = await ConfigurationHandler.readConfig({
+			configPath,
+		})
+
+		const baseDir = configPath ? path.dirname(configFilePath) : process.cwd()
+		const migrationsDir = path.resolve(baseDir, config.migrationsPath)
+		const migrationFiles = MigrationsService.getMigrations([migrationsDir])
 		const clientInstance = new Client(config)
 
 		await clientInstance.run(async ({ collection, db }) => {
+			for (const cb of config.callbacksBeforeMigrations) {
+				await cb({ db })
+			}
+
 			const migrationsService = new MigrationsService(collection)
 			const appliedMigrationsSet = await migrationsService.getAppliedSet()
 			for (const file of migrationFiles) {
 				if (!appliedMigrationsSet.has(path.parse(file).name)) {
-					const { migrate } = await import(path.join(...migrationsPath, file))
+					const { migrate } = await import(
+						pathToFileURL(path.join(migrationsDir, file)).href
+					)
 					await migrate(db)
 					await migrationsService.insertApplied(path.parse(file).name)
 					MongogratorLogger.logInfo(`Migration ${file} applied`)
 				}
+			}
+
+			for (const cb of config.callbacksAfterMigrations) {
+				await cb({ db })
 			}
 		})
 	}

--- a/src/commands/MigrateCommand.ts
+++ b/src/commands/MigrateCommand.ts
@@ -1,8 +1,10 @@
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { ConfigurationHandler } from '../config/ConfigurationHandler.js'
+import type { MongogratorMigration } from '../config/config.js'
 import { MigrationsService } from '../db/MigrationsService.js'
 import { Client } from '../db/MongoDb.js'
+import { MongogratorError } from '../errors/MongogratorError.js'
 import { MongogratorLogger } from '../loggers/MongogratorLogger.js'
 import { BaseCommandStrategy } from './BaseCommandStrategy.js'
 
@@ -16,6 +18,7 @@ export class MigrateCommand extends BaseCommandStrategy {
 		By default the config file is loaded from the current working directory; pass
 		--config <path> to point at a specific mongogrator.config.{ts,js} file.
 		The config file determines the location of the migrations folder.
+		Each migration file must default-export a value created with buildMigration({ migrate }).
 	`
 
 	async execute() {
@@ -42,10 +45,11 @@ export class MigrateCommand extends BaseCommandStrategy {
 			const appliedMigrationsSet = await migrationsService.getAppliedSet()
 			for (const file of migrationFiles) {
 				if (!appliedMigrationsSet.has(path.parse(file).name)) {
-					const { migrate } = await import(
-						pathToFileURL(path.join(migrationsDir, file)).href
+					const migration = await loadMigration(
+						path.join(migrationsDir, file),
+						file,
 					)
-					await migrate(db)
+					await migration.migrate(db)
 					await migrationsService.insertApplied(path.parse(file).name)
 					MongogratorLogger.logInfo(`Migration ${file} applied`)
 				}
@@ -56,4 +60,18 @@ export class MigrateCommand extends BaseCommandStrategy {
 			}
 		})
 	}
+}
+
+async function loadMigration(
+	absPath: string,
+	displayName: string,
+): Promise<MongogratorMigration> {
+	const mod = await import(pathToFileURL(absPath).href)
+	const migration = mod.default as MongogratorMigration | undefined
+	if (!migration || typeof migration.migrate !== 'function') {
+		throw new MongogratorError(
+			`Migration "${displayName}" must default-export a value created with buildMigration({ migrate })`,
+		)
+	}
+	return migration
 }

--- a/src/commands/MigrateCommand.ts
+++ b/src/commands/MigrateCommand.ts
@@ -16,7 +16,8 @@ export class MigrateCommand extends BaseCommandStrategy {
 		This command executes all pending migration files in the migrations directory.
 		Migrations that have already been applied are skipped.
 		By default the config file is loaded from the current working directory; pass
-		--config <path> to point at a specific mongogrator.config.{ts,js} file.
+		--config <path> or set MONGOGRATOR_CONFIG_PATH to point at a specific
+		mongogrator.config.{ts,js} file. The --config flag wins over the env var.
 		The config file determines the location of the migrations folder.
 		Each migration file must default-export a value created with buildMigration({ migrate }).
 	`
@@ -31,8 +32,10 @@ export class MigrateCommand extends BaseCommandStrategy {
 			configPath,
 		})
 
-		const baseDir = configPath ? path.dirname(configFilePath) : process.cwd()
-		const migrationsDir = path.resolve(baseDir, config.migrationsPath)
+		const migrationsDir = path.resolve(
+			path.dirname(configFilePath),
+			config.migrationsPath,
+		)
 		const migrationFiles = MigrationsService.getMigrations([migrationsDir])
 		const clientInstance = new Client(config)
 

--- a/src/commands/VersionCommand.ts
+++ b/src/commands/VersionCommand.ts
@@ -1,14 +1,6 @@
-import fs from 'node:fs'
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { MongogratorLogger } from '../loggers/MongogratorLogger.js'
+import { version } from '../pkg.js'
 import { BaseCommandStrategy } from './BaseCommandStrategy.js'
-
-const moduleDir = path.dirname(fileURLToPath(import.meta.url))
-const pkgPath = path.resolve(moduleDir, '../../package.json')
-const { version } = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')) as {
-	version: string
-}
 
 export class VersionCommand extends BaseCommandStrategy {
 	static triggers = ['version', '-v', '--version']

--- a/src/commands/VersionCommand.ts
+++ b/src/commands/VersionCommand.ts
@@ -1,6 +1,14 @@
-import { version } from '../../package.json'
-import { MongogratorLogger } from '../loggers/MongogratorLogger'
-import { BaseCommandStrategy } from './BaseCommandStrategy'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { MongogratorLogger } from '../loggers/MongogratorLogger.js'
+import { BaseCommandStrategy } from './BaseCommandStrategy.js'
+
+const moduleDir = path.dirname(fileURLToPath(import.meta.url))
+const pkgPath = path.resolve(moduleDir, '../../package.json')
+const { version } = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')) as {
+	version: string
+}
 
 export class VersionCommand extends BaseCommandStrategy {
 	static triggers = ['version', '-v', '--version']

--- a/src/config/ConfigurationHandler.ts
+++ b/src/config/ConfigurationHandler.ts
@@ -3,11 +3,12 @@ import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { MongogratorError } from '../errors/MongogratorError.js'
 import { MongogratorLogger } from '../loggers/MongogratorLogger.js'
+import type z from 'zod'
 import {
 	CONFIG_FILE_NAME,
 	CONFIG_JS_FILE_NAME,
 	CONFIG_TS_FILE_NAME,
-	type TMongogratorConfig,
+	ConfigFormatSchema,
 	mongogratorConfigSchema,
 } from './config.js'
 import { configTemplates } from './templates.js'
@@ -17,7 +18,7 @@ export type ReadConfigOptions = {
 }
 
 export type LoadedConfig = {
-	config: TMongogratorConfig
+	config: z.output<typeof mongogratorConfigSchema>
 	configFilePath: string
 }
 
@@ -55,7 +56,7 @@ export namespace ConfigurationHandler {
 
 	export async function initConfig(useJs: boolean) {
 		const fileName = useJs ? CONFIG_JS_FILE_NAME : CONFIG_TS_FILE_NAME
-		const extension = useJs ? 'js' : 'ts'
+		const extension : z.infer<typeof ConfigFormatSchema> = useJs ? 'js' : 'ts'
 		const configFilePath = path.join(process.cwd(), fileName)
 		if (fs.existsSync(configFilePath)) {
 			throw new MongogratorError(`${fileName} already initialized`)

--- a/src/config/ConfigurationHandler.ts
+++ b/src/config/ConfigurationHandler.ts
@@ -26,7 +26,7 @@ export namespace ConfigurationHandler {
 	export async function readConfig(
 		options: ReadConfigOptions = {},
 	): Promise<LoadedConfig> {
-		const { configPath } = options
+		const configPath = options.configPath ?? process.env.MONGOGRATOR_CONFIG_PATH
 
 		if (configPath) {
 			const absPath = path.resolve(process.cwd(), configPath)

--- a/src/config/ConfigurationHandler.ts
+++ b/src/config/ConfigurationHandler.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { pathToFileURL } from 'node:url'
 import type z from 'zod'
 import { MongogratorError } from '../errors/MongogratorError.js'
 import { MongogratorLogger } from '../loggers/MongogratorLogger.js'
+import { loadModule } from '../moduleLoader.js'
 import {
 	CONFIG_FILE_NAME,
 	CONFIG_JS_FILE_NAME,
@@ -33,7 +33,7 @@ export namespace ConfigurationHandler {
 			if (!fs.existsSync(absPath)) {
 				throw new MongogratorError(`Config file not found at "${absPath}"`)
 			}
-			const module = await import(pathToFileURL(absPath).href)
+			const module = (await loadModule(absPath)) as { default: unknown }
 			const config = await mongogratorConfigSchema.parseAsync(module.default)
 			return { config, configFilePath: absPath }
 		}
@@ -41,7 +41,7 @@ export namespace ConfigurationHandler {
 		for (const configFileName of [CONFIG_TS_FILE_NAME, CONFIG_JS_FILE_NAME]) {
 			const absPath = path.join(process.cwd(), configFileName)
 			if (fs.existsSync(absPath)) {
-				const module = await import(pathToFileURL(absPath).href)
+				const module = (await loadModule(absPath)) as { default: unknown }
 				const config = await mongogratorConfigSchema.parseAsync(module.default)
 				return { config, configFilePath: absPath }
 			}

--- a/src/config/ConfigurationHandler.ts
+++ b/src/config/ConfigurationHandler.ts
@@ -1,14 +1,14 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
+import type z from 'zod'
 import { MongogratorError } from '../errors/MongogratorError.js'
 import { MongogratorLogger } from '../loggers/MongogratorLogger.js'
-import type z from 'zod'
 import {
 	CONFIG_FILE_NAME,
 	CONFIG_JS_FILE_NAME,
 	CONFIG_TS_FILE_NAME,
-	ConfigFormatSchema,
+	type ConfigFormatSchema,
 	mongogratorConfigSchema,
 } from './config.js'
 import { configTemplates } from './templates.js'
@@ -31,9 +31,7 @@ export namespace ConfigurationHandler {
 		if (configPath) {
 			const absPath = path.resolve(process.cwd(), configPath)
 			if (!fs.existsSync(absPath)) {
-				throw new MongogratorError(
-					`Config file not found at "${absPath}"`,
-				)
+				throw new MongogratorError(`Config file not found at "${absPath}"`)
 			}
 			const module = await import(pathToFileURL(absPath).href)
 			const config = await mongogratorConfigSchema.parseAsync(module.default)
@@ -44,9 +42,7 @@ export namespace ConfigurationHandler {
 			const absPath = path.join(process.cwd(), configFileName)
 			if (fs.existsSync(absPath)) {
 				const module = await import(pathToFileURL(absPath).href)
-				const config = await mongogratorConfigSchema.parseAsync(
-					module.default,
-				)
+				const config = await mongogratorConfigSchema.parseAsync(module.default)
 				return { config, configFilePath: absPath }
 			}
 		}
@@ -56,7 +52,7 @@ export namespace ConfigurationHandler {
 
 	export async function initConfig(useJs: boolean) {
 		const fileName = useJs ? CONFIG_JS_FILE_NAME : CONFIG_TS_FILE_NAME
-		const extension : z.infer<typeof ConfigFormatSchema> = useJs ? 'js' : 'ts'
+		const extension: z.infer<typeof ConfigFormatSchema> = useJs ? 'js' : 'ts'
 		const configFilePath = path.join(process.cwd(), fileName)
 		if (fs.existsSync(configFilePath)) {
 			throw new MongogratorError(`${fileName} already initialized`)

--- a/src/config/ConfigurationHandler.ts
+++ b/src/config/ConfigurationHandler.ts
@@ -1,26 +1,52 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { MongogratorError } from '../errors/MongogratorError'
-import { MongogratorLogger } from '../loggers/MongogratorLogger'
+import { pathToFileURL } from 'node:url'
+import { MongogratorError } from '../errors/MongogratorError.js'
+import { MongogratorLogger } from '../loggers/MongogratorLogger.js'
 import {
 	CONFIG_FILE_NAME,
 	CONFIG_JS_FILE_NAME,
 	CONFIG_TS_FILE_NAME,
 	type TMongogratorConfig,
 	mongogratorConfigSchema,
-} from './config'
-import { configTemplates } from './templates'
+} from './config.js'
+import { configTemplates } from './templates.js'
+
+export type ReadConfigOptions = {
+	configPath?: string
+}
+
+export type LoadedConfig = {
+	config: TMongogratorConfig
+	configFilePath: string
+}
 
 export namespace ConfigurationHandler {
 	export async function readConfig(
-		customPath = '',
-	): Promise<TMongogratorConfig> {
-		for (const configFileName of [CONFIG_TS_FILE_NAME, CONFIG_JS_FILE_NAME]) {
-			const relativePath = path.join(process.cwd(), customPath, configFileName)
-			if (fs.existsSync(relativePath)) {
-				return await import(relativePath).then((module) =>
-					mongogratorConfigSchema.parseAsync(module.default),
+		options: ReadConfigOptions = {},
+	): Promise<LoadedConfig> {
+		const { configPath } = options
+
+		if (configPath) {
+			const absPath = path.resolve(process.cwd(), configPath)
+			if (!fs.existsSync(absPath)) {
+				throw new MongogratorError(
+					`Config file not found at "${absPath}"`,
 				)
+			}
+			const module = await import(pathToFileURL(absPath).href)
+			const config = await mongogratorConfigSchema.parseAsync(module.default)
+			return { config, configFilePath: absPath }
+		}
+
+		for (const configFileName of [CONFIG_TS_FILE_NAME, CONFIG_JS_FILE_NAME]) {
+			const absPath = path.join(process.cwd(), configFileName)
+			if (fs.existsSync(absPath)) {
+				const module = await import(pathToFileURL(absPath).href)
+				const config = await mongogratorConfigSchema.parseAsync(
+					module.default,
+				)
+				return { config, configFilePath: absPath }
 			}
 		}
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -17,7 +17,7 @@ const callbackSchema = z.custom<MongogratorMigrationCallback>(
 )
 
 export const mongogratorConfigSchema = z.object({
-	url: z.string().url(),
+	url: z.url(),
 	database: z.string(),
 	migrationsPath: z.string(),
 	logsCollectionName: z.string(),
@@ -28,12 +28,12 @@ export const mongogratorConfigSchema = z.object({
 
 export type MongogratorConfig = z.input<typeof mongogratorConfigSchema>
 
-export const buildMongogratorConfig = (input: z.input<typeof mongogratorConfigSchema>) =>
-	mongogratorConfigSchema.parse(input)
+export const buildMongogratorConfig = (
+	input: z.input<typeof mongogratorConfigSchema>,
+) => mongogratorConfigSchema.parse(input)
 
 export type MongogratorMigration = {
 	migrate: (db: Db) => Promise<void>
 }
 
 export const buildMigration = (input: MongogratorMigration) => input
-

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -21,6 +21,13 @@ const callbackSchema = z.custom<MongogratorMigrationCallback>(
 	{ message: 'Callback must be a function' },
 )
 
+export type MongogratorGenerateId = () => unknown
+
+const generateIdSchema = z.custom<MongogratorGenerateId>(
+	(val) => typeof val === 'function',
+	{ message: 'generateId must be a function' },
+)
+
 export const mongogratorConfigSchema = z.object({
 	url: z.url(),
 	database: z.string(),
@@ -29,6 +36,7 @@ export const mongogratorConfigSchema = z.object({
 	format: ConfigFormatSchema,
 	callbacksBeforeMigrations: callbackSchema.array().optional().default([]),
 	callbacksAfterMigrations: callbackSchema.array().optional().default([]),
+	generateId: generateIdSchema.optional(),
 })
 
 export type MongogratorConfig = z.input<typeof mongogratorConfigSchema>

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -5,7 +5,7 @@ export const CONFIG_FILE_NAME = 'mongogrator.config'
 export const CONFIG_TS_FILE_NAME = `${CONFIG_FILE_NAME}.ts`
 export const CONFIG_JS_FILE_NAME = `${CONFIG_FILE_NAME}.js`
 
-const ConfigFormatSchema = z.enum(['js', 'ts'])
+export const ConfigFormatSchema = z.enum(['js', 'ts'])
 
 export type MongogratorMigrationCallback = (args: {
 	db: Db
@@ -22,8 +22,18 @@ export const mongogratorConfigSchema = z.object({
 	migrationsPath: z.string(),
 	logsCollectionName: z.string(),
 	format: ConfigFormatSchema,
-	callbacksBeforeMigrations: z.array(callbackSchema).default([]),
-	callbacksAfterMigrations: z.array(callbackSchema).default([]),
+	callbacksBeforeMigrations: callbackSchema.array().optional().default([]),
+	callbacksAfterMigrations: callbackSchema.array().optional().default([]),
 })
 
-export type TMongogratorConfig = z.infer<typeof mongogratorConfigSchema>
+export type MongogratorConfig = z.input<typeof mongogratorConfigSchema>
+
+export const buildMongogratorConfig = (input: z.input<typeof mongogratorConfigSchema>) =>
+	mongogratorConfigSchema.parse(input)
+
+export type MongogratorMigration = {
+	migrate: (db: Db) => Promise<void>
+}
+
+export const buildMigration = (input: MongogratorMigration) => input
+

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,26 +1,29 @@
+import type { Db } from 'mongodb'
 import { z } from 'zod'
 
 export const CONFIG_FILE_NAME = 'mongogrator.config'
 export const CONFIG_TS_FILE_NAME = `${CONFIG_FILE_NAME}.ts`
 export const CONFIG_JS_FILE_NAME = `${CONFIG_FILE_NAME}.js`
 
-export enum ConfigFormat {
-	js = 'js',
-	ts = 'ts',
-}
+const ConfigFormatSchema = z.enum(['js', 'ts'])
 
-export type TMongogratorConfig = {
-	url: string
-	database: string
-	migrationsPath: string
-	logsCollectionName: string
-	format: ConfigFormat
-}
+export type MongogratorMigrationCallback = (args: {
+	db: Db
+}) => Promise<void>
+
+const callbackSchema = z.custom<MongogratorMigrationCallback>(
+	(val) => typeof val === 'function',
+	{ message: 'Callback must be a function' },
+)
 
 export const mongogratorConfigSchema = z.object({
-	url: z.string().url(), // Validates the cluster URL
-	database: z.string(), // Database name
-	migrationsPath: z.string(), // Migrations directory path
-	logsCollectionName: z.string(), // Logs collection name
-	format: z.nativeEnum(ConfigFormat), // Format must be either 'ts' or 'js'
+	url: z.string().url(),
+	database: z.string(),
+	migrationsPath: z.string(),
+	logsCollectionName: z.string(),
+	format: ConfigFormatSchema,
+	callbacksBeforeMigrations: z.array(callbackSchema).default([]),
+	callbacksAfterMigrations: z.array(callbackSchema).default([]),
 })
+
+export type TMongogratorConfig = z.infer<typeof mongogratorConfigSchema>

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,4 +1,4 @@
-import type { Db } from 'mongodb'
+import type { Db, MongoClient } from 'mongodb'
 import { z } from 'zod'
 
 export const CONFIG_FILE_NAME = 'mongogrator.config'
@@ -7,9 +7,14 @@ export const CONFIG_JS_FILE_NAME = `${CONFIG_FILE_NAME}.js`
 
 export const ConfigFormatSchema = z.enum(['js', 'ts'])
 
-export type MongogratorMigrationCallback = (args: {
+export type MongogratorMigrationArgs = {
 	db: Db
-}) => Promise<void>
+	client: MongoClient
+}
+
+export type MongogratorMigrationCallback = (
+	args: MongogratorMigrationArgs,
+) => Promise<void>
 
 const callbackSchema = z.custom<MongogratorMigrationCallback>(
 	(val) => typeof val === 'function',
@@ -33,7 +38,7 @@ export const buildMongogratorConfig = (
 ) => mongogratorConfigSchema.parse(input)
 
 export type MongogratorMigration = {
-	migrate: (db: Db) => Promise<void>
+	migrate: (args: MongogratorMigrationArgs) => Promise<void>
 }
 
 export const buildMigration = (input: MongogratorMigration) => input

--- a/src/config/templates.ts
+++ b/src/config/templates.ts
@@ -1,31 +1,35 @@
 export const configTemplates = {
-	ts: `
+	ts: `import { mongogratorConfigSchema, type TMongogratorConfig } from 'mongogrator'
+
+const mongogratorConfig: TMongogratorConfig = mongogratorConfigSchema.parse({
+	url: 'mongodb://localhost:27017', // Cluster url
+	database: 'test', // Database name for which the migrations will be executed
+	migrationsPath: './migrations', // Migrations directory relative to the location of the config file
+	logsCollectionName: 'migrations', // Name of the logs collection that will be stored in the database
+	format: 'ts', // Format type of the migration files ['ts', 'js']
+	callbacksBeforeMigrations: [], // Async hooks (args: { db }) => Promise<void>, run once before the batch
+	callbacksAfterMigrations: [], // Async hooks (args: { db }) => Promise<void>, run once after the batch
+})
+
+export default mongogratorConfig
+`,
+	js: `/** @type {import('mongogrator').TMongogratorConfig} */
 const mongogratorConfig = {
 	url: 'mongodb://localhost:27017', // Cluster url
 	database: 'test', // Database name for which the migrations will be executed
-	migrationsPath: './migrations', // Migrations directory relative to the location of the commands
+	migrationsPath: './migrations', // Migrations directory relative to the location of the config file
 	logsCollectionName: 'migrations', // Name of the logs collection that will be stored in the database
-	format: 'ts', // Format type of the migration files ['ts', 'js']
+	format: 'js', // Format type of the migration files ['ts', 'js']
+	callbacksBeforeMigrations: [], // Async hooks ({ db }) => Promise<void>, run once before the batch
+	callbacksAfterMigrations: [], // Async hooks ({ db }) => Promise<void>, run once after the batch
 }
 
 export default mongogratorConfig
 `,
-	js: `
-const mongogratorConfig = {
-	url: 'mongodb://localhost:27017', // Cluster url
-	database: 'test', // Database name for which the migrations will be executed
-	migrationsPath: './migrations', // Migrations directory relative to the location of the commands
-	logsCollectionName: 'migrations', // Name of the logs collection that will be stored in the database
-	format: 'js', // Format type of the migration files ['ts', 'js']
-}
-
-module.exports = mongogratorConfig
-`,
 }
 
 export const migrationTemplates = {
-	ts: `
-import type { Db } from 'mongodb'
+	ts: `import type { Db } from 'mongodb'
 
 /**
  * This function is called when the migration is run.
@@ -35,16 +39,13 @@ export const migrate = async (_db: Db): Promise<void> => {
 	// Migration code here
 }
 `,
-	js: `
-/**
+	js: `/**
  * This function is called when the migration is run.
  * @param {import("mongodb").Db} _db The mongodb database object that's passed to the migration
  * @returns {Promise<void>}
  */
-const migrate = async (_db) => {
+export const migrate = async (_db) => {
 	// Migration code here
 }
-
-module.exports = { migrate }
 `,
 }

--- a/src/config/templates.ts
+++ b/src/config/templates.ts
@@ -3,24 +3,24 @@ export const configTemplates = {
 
 export default buildMongogratorConfig({
 	url: 'mongodb://localhost:27017', // Cluster url
-	database: 'test', // Database name for which the migrations will be executed
+	database: 'test', // Default database name injected as 'db' into migrations/hooks
 	migrationsPath: './migrations', // Migrations directory relative to the location of the config file
 	logsCollectionName: 'migrations', // Name of the logs collection that will be stored in the database
 	format: 'ts', // Format type of the migration files ['ts', 'js']
-	callbacksBeforeMigrations: [], // Async hooks (args: { db }) => Promise<void>, run once before the batch
-	callbacksAfterMigrations: [], // Async hooks (args: { db }) => Promise<void>, run once after the batch
+	callbacksBeforeMigrations: [], // Async hooks ({ db, client }) => Promise<void>, run once before the batch
+	callbacksAfterMigrations: [], // Async hooks ({ db, client }) => Promise<void>, run once after the batch
 })
 `,
 	js: `import { buildMongogratorConfig } from '@danieljanocha/mongogrator'
 
 export default buildMongogratorConfig({
 	url: 'mongodb://localhost:27017', // Cluster url
-	database: 'test', // Database name for which the migrations will be executed
+	database: 'test', // Default database name injected as 'db' into migrations/hooks
 	migrationsPath: './migrations', // Migrations directory relative to the location of the config file
 	logsCollectionName: 'migrations', // Name of the logs collection that will be stored in the database
 	format: 'js', // Format type of the migration files ['ts', 'js']
-	callbacksBeforeMigrations: [], // Async hooks ({ db }) => Promise<void>, run once before the batch
-	callbacksAfterMigrations: [], // Async hooks ({ db }) => Promise<void>, run once after the batch
+	callbacksBeforeMigrations: [], // Async hooks ({ db, client }) => Promise<void>, run once before the batch
+	callbacksAfterMigrations: [], // Async hooks ({ db, client }) => Promise<void>, run once after the batch
 })
 `,
 }
@@ -29,16 +29,22 @@ export const migrationTemplates = {
 	ts: `import { buildMigration } from '@danieljanocha/mongogrator'
 
 export default buildMigration({
-	migrate: async (_db) => {
-		// Migration code here
+	migrate: async ({ db, client }) => {
+		// 'db' is the default database from config.database
+		// 'client' is the underlying MongoClient — use it for multi-database setups, e.g.:
+		//   const authDb = client.db('auth')
+		//   const twitchDb = client.db('twitch')
 	},
 })
 `,
 	js: `import { buildMigration } from '@danieljanocha/mongogrator'
 
 export default buildMigration({
-	migrate: async (_db) => {
-		// Migration code here
+	migrate: async ({ db, client }) => {
+		// 'db' is the default database from config.database
+		// 'client' is the underlying MongoClient — use it for multi-database setups, e.g.:
+		//   const authDb = client.db('auth')
+		//   const twitchDb = client.db('twitch')
 	},
 })
 `,

--- a/src/config/templates.ts
+++ b/src/config/templates.ts
@@ -9,6 +9,7 @@ export default buildMongogratorConfig({
 	format: 'ts', // Format type of the migration files ['ts', 'js']
 	callbacksBeforeMigrations: [], // Async hooks ({ db, client }) => Promise<void>, run once before the batch
 	callbacksAfterMigrations: [], // Async hooks ({ db, client }) => Promise<void>, run once after the batch
+	// generateId: () => crypto.randomUUID(), // Optional. Sets the _id of every row inserted into the logs collection. Default: MongoDB auto-generated ObjectId.
 })
 `,
 	js: `import { buildMongogratorConfig } from '@danieljanocha/mongogrator'
@@ -21,6 +22,7 @@ export default buildMongogratorConfig({
 	format: 'js', // Format type of the migration files ['ts', 'js']
 	callbacksBeforeMigrations: [], // Async hooks ({ db, client }) => Promise<void>, run once before the batch
 	callbacksAfterMigrations: [], // Async hooks ({ db, client }) => Promise<void>, run once after the batch
+	// generateId: () => crypto.randomUUID(), // Optional. Sets the _id of every row inserted into the logs collection. Default: MongoDB auto-generated ObjectId.
 })
 `,
 }

--- a/src/config/templates.ts
+++ b/src/config/templates.ts
@@ -1,7 +1,7 @@
 export const configTemplates = {
-	ts: `import { mongogratorConfigSchema, type TMongogratorConfig } from 'mongogrator'
+	ts: `import { buildMongogratorConfig } from '@danieljanocha/mongogrator'
 
-const mongogratorConfig: TMongogratorConfig = mongogratorConfigSchema.parse({
+export default buildMongogratorConfig({
 	url: 'mongodb://localhost:27017', // Cluster url
 	database: 'test', // Database name for which the migrations will be executed
 	migrationsPath: './migrations', // Migrations directory relative to the location of the config file
@@ -10,11 +10,10 @@ const mongogratorConfig: TMongogratorConfig = mongogratorConfigSchema.parse({
 	callbacksBeforeMigrations: [], // Async hooks (args: { db }) => Promise<void>, run once before the batch
 	callbacksAfterMigrations: [], // Async hooks (args: { db }) => Promise<void>, run once after the batch
 })
-
-export default mongogratorConfig
 `,
-	js: `/** @type {import('mongogrator').TMongogratorConfig} */
-const mongogratorConfig = {
+	js: `import { buildMongogratorConfig } from '@danieljanocha/mongogrator'
+
+export default buildMongogratorConfig({
 	url: 'mongodb://localhost:27017', // Cluster url
 	database: 'test', // Database name for which the migrations will be executed
 	migrationsPath: './migrations', // Migrations directory relative to the location of the config file
@@ -22,30 +21,25 @@ const mongogratorConfig = {
 	format: 'js', // Format type of the migration files ['ts', 'js']
 	callbacksBeforeMigrations: [], // Async hooks ({ db }) => Promise<void>, run once before the batch
 	callbacksAfterMigrations: [], // Async hooks ({ db }) => Promise<void>, run once after the batch
-}
-
-export default mongogratorConfig
+})
 `,
 }
 
 export const migrationTemplates = {
-	ts: `import type { Db } from 'mongodb'
+	ts: `import { buildMigration } from '@danieljanocha/mongogrator'
 
-/**
- * This function is called when the migration is run.
- * @param _db The mongodb database object that's passed to the migration
- */
-export const migrate = async (_db: Db): Promise<void> => {
-	// Migration code here
-}
+export default buildMigration({
+	migrate: async (_db) => {
+		// Migration code here
+	},
+})
 `,
-	js: `/**
- * This function is called when the migration is run.
- * @param {import("mongodb").Db} _db The mongodb database object that's passed to the migration
- * @returns {Promise<void>}
- */
-export const migrate = async (_db) => {
-	// Migration code here
-}
+	js: `import { buildMigration } from '@danieljanocha/mongogrator'
+
+export default buildMigration({
+	migrate: async (_db) => {
+		// Migration code here
+	},
+})
 `,
 }

--- a/src/db/MigrationsService.ts
+++ b/src/db/MigrationsService.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import type { Collection } from 'mongodb'
+import type { Collection, OptionalUnlessRequiredId } from 'mongodb'
+import type { MongogratorGenerateId } from '../config/config.js'
 import { MongogratorError } from '../errors/MongogratorError.js'
 
 export type TMigration = {
@@ -9,7 +10,10 @@ export type TMigration = {
 }
 
 export class MigrationsService {
-	constructor(private readonly collection: Collection<TMigration>) {}
+	constructor(
+		private readonly collection: Collection<TMigration>,
+		private readonly generateId?: MongogratorGenerateId,
+	) {}
 
 	public async getAppliedSet() {
 		return new Set(
@@ -22,10 +26,15 @@ export class MigrationsService {
 	}
 
 	public async insertApplied(migrationName: string) {
-		return this.collection.insertOne({
+		const generatedId = this.generateId?.()
+		const doc = {
 			name: migrationName,
 			createdAt: new Date(),
-		})
+			_id: generatedId
+		}
+		return this.collection.insertOne(
+			doc as unknown as OptionalUnlessRequiredId<TMigration>,
+		)
 	}
 
 	public static getMigrations(pathArray: string[]) {

--- a/src/db/MigrationsService.ts
+++ b/src/db/MigrationsService.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import type { Collection } from 'mongodb'
-import { MongogratorError } from '../errors/MongogratorError'
+import { MongogratorError } from '../errors/MongogratorError.js'
 
 export type TMigration = {
 	name: string

--- a/src/db/MongoDb.ts
+++ b/src/db/MongoDb.ts
@@ -1,6 +1,6 @@
 import { type Collection, type Db, MongoClient } from 'mongodb'
-import type { TMongogratorConfig } from '../config/config'
-import type { TMigration } from './MigrationsService'
+import type { TMongogratorConfig } from '../config/config.js'
+import type { TMigration } from './MigrationsService.js'
 
 export class Client {
 	client: MongoClient

--- a/src/db/MongoDb.ts
+++ b/src/db/MongoDb.ts
@@ -14,7 +14,11 @@ export class Client {
 
 	public run = async (
 		fn: (
-			clientArgs: { db: Db; collection: Collection<TMigration> },
+			clientArgs: {
+				db: Db
+				client: MongoClient
+				collection: Collection<TMigration>
+			},
 			...args: any[]
 		) => Promise<any>,
 		...args: any[]
@@ -22,7 +26,7 @@ export class Client {
 		try {
 			await this.client.connect()
 			const result = await fn(
-				{ db: this.db, collection: this.collection },
+				{ db: this.db, client: this.client, collection: this.collection },
 				...args,
 			)
 			return result

--- a/src/db/MongoDb.ts
+++ b/src/db/MongoDb.ts
@@ -1,12 +1,12 @@
 import { type Collection, type Db, MongoClient } from 'mongodb'
-import type { TMongogratorConfig } from '../config/config.js'
+import type { MongogratorConfig } from '../config/config.js'
 import type { TMigration } from './MigrationsService.js'
 
 export class Client {
 	client: MongoClient
 	db: Db
 	collection: Collection<TMigration>
-	constructor(config: TMongogratorConfig) {
+	constructor(config: MongogratorConfig) {
 		this.client = new MongoClient(config.url)
 		this.db = this.client.db(config.database)
 		this.collection = this.db.collection(config.logsCollectionName)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
-import { CommandExecutor } from './commands/CommandExecutor'
-import { MongogratorLogger } from './loggers/MongogratorLogger'
+#!/usr/bin/env node
+import { CommandExecutor } from './commands/CommandExecutor.js'
+import { MongogratorLogger } from './loggers/MongogratorLogger.js'
 ;(async () => {
 	const start = Date.now()
 	await new CommandExecutor(process.argv).executeCommand().catch((err) => {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -3,6 +3,7 @@ export {
 	buildMongogratorConfig,
 	mongogratorConfigSchema,
 	type MongogratorMigration,
+	type MongogratorMigrationArgs,
 	type MongogratorMigrationCallback,
 	type MongogratorConfig,
 } from './config/config.js'

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,0 +1,5 @@
+export {
+	mongogratorConfigSchema,
+	type MongogratorMigrationCallback,
+	type TMongogratorConfig,
+} from './config/config.js'

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,5 +1,8 @@
 export {
+	buildMigration,
+	buildMongogratorConfig,
 	mongogratorConfigSchema,
+	type MongogratorMigration,
 	type MongogratorMigrationCallback,
-	type TMongogratorConfig,
+	type MongogratorConfig,
 } from './config/config.js'

--- a/src/loggers/MongogratorLogger.ts
+++ b/src/loggers/MongogratorLogger.ts
@@ -1,11 +1,29 @@
 import { MongogratorError } from '../errors/MongogratorError.js'
 
+const ANSI = {
+	reset: '\x1b[0m',
+	bold: '\x1b[1m',
+	blue: '\x1b[34m',
+	red: '\x1b[31m',
+} as const
+
+// Honor the NO_COLOR convention (https://no-color.org) so output can be
+// forced plain when desired. Otherwise colorize even outside a TTY, since
+// CI log viewers such as Vercel build logs render ANSI codes.
+const colorEnabled = !process.env.NO_COLOR
+
+const colorize = ({ text, codes }: { text: string; codes: string[] }) =>
+	colorEnabled ? `${codes.join('')}${text}${ANSI.reset}` : text
+
 export namespace MongogratorLogger {
-	const prefixLog = (level: string) =>
-		`[Mongogrator:${new Date().toISOString().split('.')[0]}:${level}]`
+	const prefixLog = (level: string, color: string) =>
+		colorize({
+			text: `[Mongogrator:${new Date().toISOString().split('.')[0]}:${level}]`,
+			codes: [ANSI.bold, color],
+		})
 
 	export function logInfo(...values: unknown[]) {
-		console.log(prefixLog('info'), ...values)
+		console.log(prefixLog('info', ANSI.blue), ...values)
 	}
 
 	export function logError(error: Error): void
@@ -13,13 +31,13 @@ export namespace MongogratorLogger {
 	export function logError(errorOrMessage: Error | string) {
 		if (errorOrMessage instanceof Error) {
 			console.error(
-				prefixLog('error'),
+				prefixLog('error', ANSI.red),
 				...(errorOrMessage instanceof MongogratorError
 					? [errorOrMessage.name, errorOrMessage.message]
 					: [errorOrMessage.stack]),
 			)
 		} else {
-			console.error(prefixLog('error'), errorOrMessage)
+			console.error(prefixLog('error', ANSI.red), errorOrMessage)
 		}
 	}
 }

--- a/src/loggers/MongogratorLogger.ts
+++ b/src/loggers/MongogratorLogger.ts
@@ -1,4 +1,4 @@
-import { MongogratorError } from '../errors/MongogratorError'
+import { MongogratorError } from '../errors/MongogratorError.js'
 
 export namespace MongogratorLogger {
 	const prefixLog = (level: string) =>

--- a/src/moduleLoader.ts
+++ b/src/moduleLoader.ts
@@ -1,0 +1,19 @@
+import { createJiti } from 'jiti'
+
+/**
+ * Shared jiti instance used to import user-authored TypeScript files
+ * (the config and migration files) at runtime.
+ *
+ * Consumers run mongogrator with plain `node`, which cannot import `.ts`
+ * files on its own. jiti transpiles them on the fly so no loader flag
+ * (e.g. `NODE_OPTIONS="--import tsx"`) is required on the consumer side.
+ */
+const jiti = createJiti(import.meta.url)
+
+/**
+ * Imports a module from an absolute path, transparently handling both
+ * `.ts` and `.js` files. Returns the full module namespace.
+ */
+export async function loadModule(absPath: string): Promise<unknown> {
+	return jiti.import(absPath)
+}

--- a/src/pkg.ts
+++ b/src/pkg.ts
@@ -1,0 +1,10 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const moduleDir = path.dirname(fileURLToPath(import.meta.url))
+const pkgPath = path.resolve(moduleDir, '../package.json')
+
+export const { version } = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')) as {
+	version: string
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,16 +2,16 @@
   "compilerOptions": {
     "lib": ["ESNext"],
     "target": "ESNext",
-    "module": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "moduleDetection": "force",
     "allowJs": true,
     "resolveJsonModule": true,
-
-    // Bundler mode
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
-    "noEmit": true,
+
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "declaration": true,
 
     // Best practices
     "strict": true,
@@ -20,7 +20,7 @@
 
     // Some stricter flags
     "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noUnusedParameters": true
   },
-  "include": ["src/**/*.ts", "assets/*.js", "assets/*.ts"]
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
                                                                                                                                                 
  1. **ESM-native package** — switch to `"type": "module"`, emit Node ESM via tsc (NodeNext), `.js` extensions on relative imports, ESM templates.
  No CommonJS leftovers in source.                                                                                                                 
  2. **`--config <path>` flag** on `migrate` / `add` / `list` — supports `--config foo.ts` and `--config=foo.ts`. When set, `migrationsPath`
  resolves relative to the config file's directory. Replaces the positional `[config_path]` on `migrate`.                                          
  3. **`callbacksBeforeMigrations` / `callbacksAfterMigrations`** in the config schema — async hooks `(args: { db }) => Promise<void>`, fired once 
  before/after the batch. Errors abort the run; the Mongo client still closes via the existing `finally`.                                         
  4. **Library exports from package root** — new `src/lib.ts` exports `mongogratorConfigSchema`, `MongogratorConfig`,                              
  `MongogratorMigrationCallback`, plus `buildMongogratorConfig` and `buildMigration` builder helpers. `package.json` `main`/`types`/`exports` point
   at `dist/lib.js` so `import 'mongogrator'` doesn't trigger the CLI IIFE; `bin` still serves the CLI.                                            
                                                                                                       
  Migration files now use `export default buildMigration({ migrate })` — the migrate command validates the shape and errors clearly if a file is   
  missing the default export. This also eliminates the "exported `migratee` instead of `migrate`" footgun.                                         
                                                                                                          
  ## Breaking changes                                                                                                                              
                                                         
  - `"type": "module"` — anyone consuming the bin via Node ESM is fine; bun/standalone binaries unaffected.
  - Migration files must now default-export via `buildMigration({ migrate })`. Old `export const migrate` files won't run; update with the helper. 
  - `mongogrator migrate <positional_path>` is replaced by `mongogrator migrate --config <path>`.                                                 
                                                                                                                                                   
  Happy to split this into 3 separate PRs (ESM / `--config` / hooks+exports) if you'd prefer smaller review units — just say the word.             
                                                                                                                                                   
  ## Test plan                                                                                                                                     
                                                                                                                                                   
  - [x] `tsc` builds clean; `dist/lib.{js,d.ts}` and `dist/index.js` (with shebang) emitted
  - [x] CLI runs as ESM: `node dist/index.js -v`, help text shows new `--config` global flag                                                       
  - [x] Library import from a separate ESM project: `mongogratorConfigSchema.parse({...})` returns typed config; no CLI side-effects on import
  - [x] `--config ./foo.config.ts`, `--config=./foo.config.ts`, and a missing-path case all behave correctly                                       
  - [x] Callbacks fire in order around the batch; thrown error in a before-callback aborts before any migration applies                            
                                                                                                                                                   
  Pre-PR cleanup to do before you click submit: drop the @danieljanocha/mongogrator references from the README hunk and the templates (replace with
   'mongogrator'), and drop the upstream-shoutout blockquote (it'd be self-referential in the upstream repo). Easiest way: open the PR from a fresh
   branch where you cherry-pick only the source changes, not those three README/install-flavor commits.             